### PR TITLE
Now clicking "show more" thumbed up tracks for user automatically + artist name parsing error fix

### DIFF
--- a/lib/Thumbups.js
+++ b/lib/Thumbups.js
@@ -27,16 +27,16 @@ var Thumbups = {
          //  Extract from "Thumbed-up Tracks" on each station
          var thumbedupTracks = $('ul.thumb_up_list,ul.song_list').find('li');
          for (var i = 0; thumbedupTracks.length > i; i++) {
-             var title = $(thumbedupTracks[i]).find('h3 a:first').text();
-             var artist = normalizeArtist($(thumbedupTracks[i]).data('artist'));
+             var title = normalizeName($(thumbedupTracks[i]).find('h3 a:first').text());
+             var artist = normalizeName($(thumbedupTracks[i]).data('artist'));
              var track = makeTrack(title, artist);
              push(track);
          }
          //  Extract from Bookmarks/Likes
          var bookmarkTracks = $('div[trackbookmark],div[id^=tracklike]');
          for (var i = 0; bookmarkTracks.length > i; i++) {
-             var title = $(bookmarkTracks[i]).find('h3 a').text();
-             var artist = normalizeArtist($(bookmarkTracks[i]).find('p a:first').text());
+             var title = normalizeName($(bookmarkTracks[i]).find('h3 a').text());
+             var artist = normalizeName($(bookmarkTracks[i]).find('p a:first').text());
              var track = makeTrack(title, artist);
              push(track);
          }
@@ -51,7 +51,7 @@ var Thumbups = {
         data.push(newElement);
       }
     }
-    function normalizeArtist(artist)
+    function normalizeName(artist)
     {
       if(typeof artist == 'string') return artist.split('(')[0];
       else return artist.toString();

--- a/lib/Thumbups.js
+++ b/lib/Thumbups.js
@@ -28,7 +28,7 @@ var Thumbups = {
          var thumbedupTracks = $('ul.thumb_up_list,ul.song_list').find('li');
          for (var i = 0; thumbedupTracks.length > i; i++) {
              var title = $(thumbedupTracks[i]).find('h3 a:first').text();
-             var artist = $(thumbedupTracks[i]).data('artist');
+             var artist = normalizeArtist($(thumbedupTracks[i]).data('artist'));
              var track = makeTrack(title, artist);
              push(track);
          }
@@ -53,7 +53,8 @@ var Thumbups = {
     }
     function normalizeArtist(artist)
     {
-      return artist.split('(')[0];
+      if(typeof artist == 'string') return artist.split('(')[0];
+      else return artist.toString();
     }
     function makeTrack(title, artist)
     {

--- a/lib/Thumbups.js
+++ b/lib/Thumbups.js
@@ -27,8 +27,9 @@ var Thumbups = {
          //  Extract from "Thumbed-up Tracks" on each station
          var thumbedupTracks = $('ul.thumb_up_list,ul.song_list').find('li');
          for (var i = 0; thumbedupTracks.length > i; i++) {
-             var artist = normalizeArtist($(thumbedupTracks[i]).data('artist'));
-             var track = makeTrack($(thumbedupTracks[i]).find('h3 a:first').text(), artist);
+             var title = $(thumbedupTracks[i]).find('h3 a:first').text();
+             var artist = $(thumbedupTracks[i]).data('artist');
+             var track = makeTrack(title, artist);
              push(track);
          }
          //  Extract from Bookmarks/Likes
@@ -36,7 +37,8 @@ var Thumbups = {
          for (var i = 0; bookmarkTracks.length > i; i++) {
              var title = $(bookmarkTracks[i]).find('h3 a').text();
              var artist = normalizeArtist($(bookmarkTracks[i]).find('p a:first').text());
-             push(makeTrack(title, artist));
+             var track = makeTrack(title, artist);
+             push(track);
          }
          return data;
 

--- a/lib/Thumbups.js
+++ b/lib/Thumbups.js
@@ -1,36 +1,44 @@
-var getElementByXpath = function (path) {
-    return document.evaluate(path, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-};
 
-var revealAllThumbedUpTracks = function(){
-	var $moreThumbUpsBtn = getElementByXpath("//ul[@class='thumb_up_list']//div[@class='show_more' and not(contains(@style,'display: none'))]");
-	if(typeof $moreThumbUpsBtn != 'undefined'){
-		console.log($moreThumbUpsBtn);
-		$moreThumbUpsBtn.click();
-		window.setTimeout(revealAllThumbedUpTracks,1000);
-	}
-};
 
 var Thumbups = {
   get: function(){
-	revealAllThumbedUpTracks();
-	
-    var data = [];
-    //  Extract from "Thumbed-up Tracks" on each station
-    var thumbedupTracks = $('ul.thumb_up_list,ul.song_list').find('li');
-    for (var i = 0; thumbedupTracks.length > i; i++) {
-      var artist = normalizeArtist($(thumbedupTracks[i]).data('artist'));
-      var track = makeTrack($(thumbedupTracks[i]).find('h3 a:first').text(), artist);
-      push(track);
-    }
-    //  Extract from Bookmarks/Likes
-    var bookmarkTracks = $('div[trackbookmark],div[id^=tracklike]');
-    for (var i = 0; bookmarkTracks.length > i; i++) {
-      var title = $(bookmarkTracks[i]).find('h3 a').text();
-      var artist = normalizeArtist($(bookmarkTracks[i]).find('p a:first').text());
-      push(makeTrack(title, artist));
-    }
-    return data;
+	return revealAllThumbedUpTracks();
+
+      function revealAllThumbedUpTracks(){
+          var $moreThumbUpsBtn = getElementByXpath("//ul[@class='thumb_up_list']//div[@class='show_more' and not(contains(@style,'display: none'))]");
+          if($moreThumbUpsBtn != null){
+              console.log($moreThumbUpsBtn);
+              $moreThumbUpsBtn.click();
+              window.setTimeout(revealAllThumbedUpTracks,1000);
+          }
+          else{
+              return getData();
+          }
+      }
+
+      function getElementByXpath(path) {
+          return document.evaluate(path, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      }
+
+     function getData()
+     {
+         console.log("getting tracks");
+         var data = [];
+         //  Extract from "Thumbed-up Tracks" on each station
+         var thumbedupTracks = $('ul.thumb_up_list,ul.song_list').find('li');
+         for (var i = 0; thumbedupTracks.length > i; i++) {
+             var artist = normalizeArtist($(thumbedupTracks[i]).data('artist'));
+             var track = makeTrack($(thumbedupTracks[i]).find('h3 a:first').text(), artist);
+             push(track);
+         }
+         //  Extract from Bookmarks/Likes
+         var bookmarkTracks = $('div[trackbookmark],div[id^=tracklike]');
+         for (var i = 0; bookmarkTracks.length > i; i++) {
+             var title = $(bookmarkTracks[i]).find('h3 a').text();
+             var artist = normalizeArtist($(bookmarkTracks[i]).find('p a:first').text());
+             push(makeTrack(title, artist));
+         }
+         return data;
 
     function push(newElement)
     {
@@ -49,5 +57,5 @@ var Thumbups = {
     {
       return {title: title, artist: artist};
     }
-  }
+  }      }
 };

--- a/lib/Thumbups.js
+++ b/lib/Thumbups.js
@@ -1,5 +1,20 @@
+var getElementByXpath = function (path) {
+    return document.evaluate(path, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+};
+
+var revealAllThumbedUpTracks = function(){
+	var $moreThumbUpsBtn = getElementByXpath("//ul[@class='thumb_up_list']//div[@class='show_more' and not(contains(@style,'display: none'))]");
+	if(typeof $moreThumbUpsBtn != 'undefined'){
+		console.log($moreThumbUpsBtn);
+		$moreThumbUpsBtn.click();
+		window.setTimeout(revealAllThumbedUpTracks,1000);
+	}
+};
+
 var Thumbups = {
   get: function(){
+	revealAllThumbedUpTracks();
+	
     var data = [];
     //  Extract from "Thumbed-up Tracks" on each station
     var thumbedupTracks = $('ul.thumb_up_list,ul.song_list').find('li');

--- a/pandoratospotify.js
+++ b/pandoratospotify.js
@@ -2,7 +2,8 @@
 var SPOTIFY_METADATA_API_ENDPOINT = 'http://ws.spotify.com/search/1/track.json';
 var GOOGLE_GEOCODING_API_ENDPOINT = 'http://maps.googleapis.com/maps/api/geocode/json';
 var countryCode = null;
-$(document).ready(function(){
+
+$(document).ready(function(){	
     var $queue = $('<div></div>');
     $queue.queue(function(){
         navigator.geolocation.getCurrentPosition(function(position){


### PR DESCRIPTION
I've added code to automatically display all thumbed up tracks by repeatedly clicking "show more" until it goes away.
I also fixed a bug seen when the artist is a number, such as "2002" as it was in my case.
I also started "normalizing" track title as many more tracks are recognized when tearing off everything after the parenthesis.
